### PR TITLE
fix identify card color

### DIFF
--- a/src/components/IdentifyCard.vue
+++ b/src/components/IdentifyCard.vue
@@ -62,7 +62,6 @@ function onClick() {
   max-width: v-bind(width);
   width: v-bind(width);
   border: 3px solid transparent;
-  background-color: $darker;
 }
 
 .identify-card:hover {


### PR DESCRIPTION
fix for issue #16 
![image](https://github.com/Snd-R/komf-userscript/assets/2584455/45f3dae9-33d9-4788-b86b-93cc34bc8340)

Someone may need to confirm if this messes things up on Kavita.  I don't have a Kavita install to check on.

I tested with prefer dark theme, but Komga doesn't seem to respect it.